### PR TITLE
fix: replace unparseable dev version constraints in require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,10 +19,10 @@
     "require-dev": {
         "phpunit/phpunit": "*",
         "phpstan/phpstan": "*",
-        "friendsofphp/php-cs-fixer": "^3.93",
-        "ergebnis/composer-normalize": "^2.48",
-        "ergebnis/php-cs-fixer-config": "^6.60",
-        "phpstan/phpstan-phpunit": "2.0.x-dev"
+        "friendsofphp/php-cs-fixer": "^3.95",
+        "ergebnis/composer-normalize": "^2.51",
+        "ergebnis/php-cs-fixer-config": "^6.61",
+        "phpstan/phpstan-phpunit": "^2.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Summary
- Replace `phpstan/phpstan-phpunit: 2.0.x-dev` with `^2.0` — `pkgtools`/`dh_phpcomposer` cannot parse `.x-dev` version strings, causing build #118 to fail with `InvalidArgumentException: Unable to parse version '2.0.x-dev'`
- Bump `friendsofphp/php-cs-fixer`, `ergebnis/composer-normalize`, and `ergebnis/php-cs-fixer-config` to their latest minor versions

## Test plan
- [ ] Jenkins build passes `dh_phpcomposer` step without `InvalidArgumentException`
- [ ] All parallel distribution branches (bookworm, trixie, forky, jammy, noble) complete successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development tooling dependencies to latest versions for improved code quality and development efficiency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/VitexSoftware/abraflexi-webhook-acceptor/pull/31)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->